### PR TITLE
Update project to .NET Standard 2.0

### DIFF
--- a/src/Serilog.Enrichers.Context/ContextLoggerConfigurationExtension.cs
+++ b/src/Serilog.Enrichers.Context/ContextLoggerConfigurationExtension.cs
@@ -118,12 +118,11 @@ namespace Serilog
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
 
             var machineName = "COMPUTERNAME";
-#if NETSTANDARD1_3
+
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 machineName = "HOSTNAME";
             }
-#endif
 
             return enrichmentConfiguration.With(new KeyValueEnricher(new KeyValuePair<string, object>("MachineName", Environment.GetEnvironmentVariable(machineName))));
         }

--- a/src/Serilog.Enrichers.Context/Serilog.Enrichers.Context.csproj
+++ b/src/Serilog.Enrichers.Context/Serilog.Enrichers.Context.csproj
@@ -30,8 +30,8 @@
         <Version>$(Version)-$(VersionSuffix)</Version>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-        <PackageReference Include="Serilog" Version="2.8.0" />
+        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Serilog" Version="2.10.0" />
     </ItemGroup>
 </Project>

--- a/src/Serilog.Enrichers.Context/Serilog.Enrichers.Context.csproj
+++ b/src/Serilog.Enrichers.Context/Serilog.Enrichers.Context.csproj
@@ -15,7 +15,7 @@
         <Version>4.5.0</Version>
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>Serilog.snk</AssemblyOriginatorKeyFile>
-        <TargetFrameworks>netstandard1.3;netcoreapp2.2;net452</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
     <PropertyGroup>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
The version of **.NET Standard 2.0** still supports **.NET Core 2.0** and **.NET Framework 4.6.1**, so compatibility is maintained, and frameworks that are not longer supported with security fixes, are no longer targeted. All dependencies have been updated as well. Ultimately, I was thinking about removing the `Newtonesoft.Json` dependency and replacing it with `System.Text.Json`, but this requires switching to **.NETStandard 2.1** and losing support for some versions of the **.NET Framework**.