### PR TITLE
Remove Newtonsoft.Json dependency

### DIFF
--- a/src/Serilog.Enrichers.Context/Enrichers/KeyValueEnricher.cs
+++ b/src/Serilog.Enrichers.Context/Enrichers/KeyValueEnricher.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Newtonsoft.Json;
-
 namespace Serilog.Enrichers
 {
     using System.Collections.Generic;
@@ -32,7 +30,7 @@ namespace Serilog.Enrichers
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
             logEvent.AddPropertyIfAbsent(
-                propertyFactory.CreateProperty(_keyValue.Key, JsonConvert.SerializeObject(_keyValue.Value)));
+                propertyFactory.CreateProperty(_keyValue.Key, _keyValue.Value, destructureObjects: true));
         }
     }
 }

--- a/src/Serilog.Enrichers.Context/Serilog.Enrichers.Context.csproj
+++ b/src/Serilog.Enrichers.Context/Serilog.Enrichers.Context.csproj
@@ -31,7 +31,6 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Serilog" Version="2.12.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
I was trying to make my images smaller and Newtonsoft is pretty large as far as dependencies go at 700KB. Since Serilog has the same functionality, I chose to rely on that instead.

I ran the build.ps1 and `dotnet test`, which both passed.